### PR TITLE
커스텀 Response, Exception 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }

--- a/src/main/java/com/fade/global/constant/ErrorCode.java
+++ b/src/main/java/com/fade/global/constant/ErrorCode.java
@@ -1,0 +1,26 @@
+package com.fade.global.constant;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    //TOKEN
+    TOKEN_SIGNATURE_ERROR(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 입니다."),
+    TOKEN_EXPIRED_ERROR(HttpStatus.UNAUTHORIZED, "토큰이 만료 되었습니다.."),
+    TOKEN_NOT_EXIST(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+
+    //MEMBER
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
+    ALREADY_EXIST_MEMBER_ID(HttpStatus.CONFLICT, "이미 사용중인 아이디입니다."),
+    INVALID_MEMBER_ID_AND_PASSWORD(HttpStatus.BAD_REQUEST, "아이디 혹은 비밀번호를 확인해주세요.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/fade/global/constant/ErrorCode.java
+++ b/src/main/java/com/fade/global/constant/ErrorCode.java
@@ -14,7 +14,11 @@ public enum ErrorCode {
     //MEMBER
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
     ALREADY_EXIST_MEMBER_ID(HttpStatus.CONFLICT, "이미 사용중인 아이디입니다."),
-    INVALID_MEMBER_ID_AND_PASSWORD(HttpStatus.BAD_REQUEST, "아이디 혹은 비밀번호를 확인해주세요.");
+    INVALID_MEMBER_ID_AND_PASSWORD(HttpStatus.BAD_REQUEST, "아이디 혹은 비밀번호를 확인해주세요."),
+
+    //POST
+    POST_UPDATE_DENIED(HttpStatus.FORBIDDEN, "게시글 수정 권한이 없습니다."),
+    POST_DELETE_DENIED(HttpStatus.FORBIDDEN, "게시글 삭제 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fade/global/dto/response/Response.java
+++ b/src/main/java/com/fade/global/dto/response/Response.java
@@ -17,11 +17,11 @@ public class Response<T> {
     }
 
     public static <T> Response<T> success(int statusCode, String message, T result) {
-        return new Response<>(statusCode, message, result);
+        return new Response<T>(statusCode, message, result);
     }
 
     public static <T> Response<T> error(int statusCode, String message, T result) {
-        return new Response<>(statusCode, message, result);
+        return new Response<T>(statusCode, message, result);
     }
 
     @Builder

--- a/src/main/java/com/fade/global/dto/response/Response.java
+++ b/src/main/java/com/fade/global/dto/response/Response.java
@@ -1,0 +1,33 @@
+package com.fade.global.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class Response<T> {
+
+    private int statusCode;
+    private String message;
+    private T result;
+
+    public static <T> Response<T> success() {
+        return new Response<T>(200, "요청에 성공했습니다.", null);
+    }
+
+    public static <T> Response<T> success(int statusCode, String message, T result) {
+        return new Response<>(statusCode, message, result);
+    }
+
+    public static <T> Response<T> error(int statusCode, String message, T result) {
+        return new Response<>(statusCode, message, result);
+    }
+
+    @Builder
+    private Response(int statusCode, String message, T result) {
+        this.statusCode = statusCode;
+        this.message = message;
+        this.result = result;
+    }
+}

--- a/src/main/java/com/fade/global/exception/ApplicationException.java
+++ b/src/main/java/com/fade/global/exception/ApplicationException.java
@@ -1,0 +1,15 @@
+package com.fade.global.exception;
+
+import com.fade.global.constant.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ApplicationException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+    public ApplicationException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/fade/global/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/fade/global/exception/GlobalExceptionAdvice.java
@@ -1,0 +1,8 @@
+package com.fade.global.exception;
+
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
+}


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
- #2 

### 어떤 부분이 변경됐나요?
- 전역적으로 사용될 Response와 커스텀 예외를 정의했습니다.

### 추가 정보 (선택)
1. gradle에 lombok추가했습니다.
2. ControllerAdvice를 Global로 만들었는데 도메인 마다 Advice 패키지를 만들어서 관리해야 유지보수가 편할지 이야기 나눠보면 좋을거 같네요
3. ErrorCode Enum 클래스의 HttpStatusCode는 https://developer.mozilla.org/ko/docs/Web/HTTP/Status를 참고했습니다.